### PR TITLE
add ci build image

### DIFF
--- a/.github/workflow/CI.yaml
+++ b/.github/workflow/CI.yaml
@@ -1,0 +1,28 @@
+name: Docker Build
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          load: true
+          tags: Docker-ecommerce:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
This pull request introduces a new workflow configuration for Docker builds in the CI pipeline. The most important change is the addition of the `.github/workflow/CI.yaml` file, which sets up and configures the Docker build process.

New CI workflow configuration:

* [`.github/workflow/CI.yaml`](diffhunk://#diff-63102847adad5bb8736591299fb3e5a6b52317d59a42b0108d9ea90078adb2f9R1-R28): Added a new workflow configuration that triggers on pushes and pull requests to the `main` branch. The workflow includes steps to checkout the code, set up Docker Buildx, and build the Docker image with caching enabled.